### PR TITLE
Retarget to .NET v4.6

### DIFF
--- a/Testing/GW2.NET.Tests/GW2NET.Tests.csproj
+++ b/Testing/GW2.NET.Tests/GW2NET.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GW2NET</RootNamespace>
     <AssemblyName>GW2NET.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -70,8 +70,9 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>
-    <Reference Include="nunit.framework">
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -138,9 +139,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\GW2NET.Core\GW2NET.Core.csproj">
       <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
       <Name>GW2NET.Core</Name>
@@ -157,6 +155,9 @@
       <Project>{48c94f34-b6bd-4bdd-a0d5-36403a86fb78}</Project>
       <Name>GW2NET</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/Testing/GW2.NET.Tests/packages.config
+++ b/Testing/GW2.NET.Tests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net40" />
-  <package id="xunit" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net452" />
+  <package id="NUnit" version="2.6.3" targetFramework="net46" />
+  <package id="xunit" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net46" />
 </packages>

--- a/src/GW2NET.Compression/GW2NET.Compression.csproj
+++ b/src/GW2NET.Compression/GW2NET.Compression.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{08D936E1-C097-4196-8128-C2493F8D7E47}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.Core/GW2NET.Core.csproj
+++ b/src/GW2NET.Core/GW2NET.Core.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{05F3D999-0470-4123-8C80-AF4AC2385E7C}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.MumbleLink.Tests/GW2NET.MumbleLink.Tests.csproj
+++ b/src/GW2NET.MumbleLink.Tests/GW2NET.MumbleLink.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GW2NET.MumbleLink</RootNamespace>
     <AssemblyName>GW2NET.MumbleLink.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
@@ -17,6 +17,7 @@
     <SccProvider>SAK</SccProvider>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/GW2NET.MumbleLink.Tests/packages.config
+++ b/src/GW2NET.MumbleLink.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
+  <package id="xunit" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net46" />
 </packages>

--- a/src/GW2NET.MumbleLink/GW2NET.MumbleLink.csproj
+++ b/src/GW2NET.MumbleLink/GW2NET.MumbleLink.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GW2NET.MumbleLink</RootNamespace>
     <AssemblyName>GW2NET.MumbleLink</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/src/GW2NET.Newtonsoft/GW2NET.Newtonsoft.csproj
+++ b/src/GW2NET.Newtonsoft/GW2NET.Newtonsoft.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{11BB8977-33FE-4789-BD5B-D977B0BF5ECF}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -54,13 +54,14 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.6\lib\portable-net45+wp80+win8+wpa81+aspnetcore50\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="GW2NET.Newtonsoft.nuspec" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.6\lib\portable-net45+wp80+win8+wpa81+aspnetcore50\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/GW2NET.Newtonsoft/packages.config
+++ b/src/GW2NET.Newtonsoft/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="portable-net45+win+wpa81" />
+  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Builds.Tests/GW2NET.V1.Builds.Tests.csproj
+++ b/src/GW2NET.V1.Builds.Tests/GW2NET.V1.Builds.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{127F6F7D-4ADC-464C-9E5B-89AE2F3ED1BA}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.Builds\GW2NET.V1.Builds.csproj">
+      <Project>{ca0da927-b8f4-4097-a7cd-a0014e0b233a}</Project>
+      <Name>GW2NET.V1.Builds</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.Builds\GW2NET.V1.Builds.csproj">
-      <Project>{ca0da927-b8f4-4097-a7cd-a0014e0b233a}</Project>
-      <Name>GW2NET.V1.Builds</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.Builds.Tests/packages.config
+++ b/src/GW2NET.V1.Builds.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Builds/GW2NET.V1.Builds.csproj
+++ b/src/GW2NET.V1.Builds/GW2NET.V1.Builds.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{CA0DA927-B8F4-4097-A7CD-A0014E0B233A}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V1.Colors.Tests/GW2NET.V1.Colors.Tests.csproj
+++ b/src/GW2NET.V1.Colors.Tests/GW2NET.V1.Colors.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8B7B5902-216E-4736-B8B7-AC337F2658A5}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,12 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.V1.Colors\GW2NET.V1.Colors.csproj">
+      <Project>{b6a516ff-684d-4e5d-9c9e-851718332a39}</Project>
+      <Name>GW2NET.V1.Colors</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,12 +69,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.V1.Colors\GW2NET.V1.Colors.csproj">
-      <Project>{b6a516ff-684d-4e5d-9c9e-851718332a39}</Project>
-      <Name>GW2NET.V1.Colors</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.Colors.Tests/packages.config
+++ b/src/GW2NET.V1.Colors.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Colors/GW2NET.V1.Colors.csproj
+++ b/src/GW2NET.V1.Colors/GW2NET.V1.Colors.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{B6A516FF-684D-4E5D-9C9E-851718332A39}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V1.Continents.Tests/GW2NET.V1.Continents.Tests.csproj
+++ b/src/GW2NET.V1.Continents.Tests/GW2NET.V1.Continents.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{0CE04E0E-BB21-49C3-B899-19FD447762CB}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.Continents\GW2NET.V1.Continents.csproj">
+      <Project>{489aaa0e-7ef9-4423-843a-fa3a11bee156}</Project>
+      <Name>GW2NET.V1.Continents</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.Continents\GW2NET.V1.Continents.csproj">
-      <Project>{489aaa0e-7ef9-4423-843a-fa3a11bee156}</Project>
-      <Name>GW2NET.V1.Continents</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.Continents.Tests/packages.config
+++ b/src/GW2NET.V1.Continents.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Continents/GW2NET.V1.Continents.csproj
+++ b/src/GW2NET.V1.Continents/GW2NET.V1.Continents.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{489AAA0E-7EF9-4423-843A-FA3A11BEE156}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V1.Events.Tests/GW2NET.V1.Events.Tests.csproj
+++ b/src/GW2NET.V1.Events.Tests/GW2NET.V1.Events.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{D8B5F446-0073-4533-BD44-6B70413BC9A4}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.Events\GW2NET.V1.Events.csproj">
+      <Project>{c7624cd0-f810-469f-b5cf-11715afc41d2}</Project>
+      <Name>GW2NET.V1.Events</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.Events\GW2NET.V1.Events.csproj">
-      <Project>{c7624cd0-f810-469f-b5cf-11715afc41d2}</Project>
-      <Name>GW2NET.V1.Events</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.Events.Tests/packages.config
+++ b/src/GW2NET.V1.Events.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Events/GW2NET.V1.Events.csproj
+++ b/src/GW2NET.V1.Events/GW2NET.V1.Events.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{C7624CD0-F810-469F-B5CF-11715AFC41D2}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V1.Files.Tests/GW2NET.V1.Files.Tests.csproj
+++ b/src/GW2NET.V1.Files.Tests/GW2NET.V1.Files.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{F7105E24-7FDC-4F38-8F91-4F0C557BD12E}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -45,6 +45,19 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05F3D999-0470-4123-8C80-AF4AC2385E7C}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.Files\GW2NET.V1.Files.csproj">
+      <Project>{25e6a850-d86e-4f4d-b824-4ab8338a0af9}</Project>
+      <Name>GW2NET.V1.Files</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -64,19 +77,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05F3D999-0470-4123-8C80-AF4AC2385E7C}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.Files\GW2NET.V1.Files.csproj">
-      <Project>{25e6a850-d86e-4f4d-b824-4ab8338a0af9}</Project>
-      <Name>GW2NET.V1.Files</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.Files.Tests/packages.config
+++ b/src/GW2NET.V1.Files.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Files/GW2NET.V1.Files.csproj
+++ b/src/GW2NET.V1.Files/GW2NET.V1.Files.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{25E6A850-D86E-4F4D-B824-4AB8338A0AF9}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V1.Floors.Tests/GW2NET.V1.Floors.Tests.csproj
+++ b/src/GW2NET.V1.Floors.Tests/GW2NET.V1.Floors.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{358B3ED3-20E0-49D3-83C4-7C4A9B3856E5}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.Floors\GW2NET.V1.Floors.csproj">
+      <Project>{a5ad09eb-690c-4adc-8af0-f0acfaae2f8f}</Project>
+      <Name>GW2NET.V1.Floors</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.Floors\GW2NET.V1.Floors.csproj">
-      <Project>{a5ad09eb-690c-4adc-8af0-f0acfaae2f8f}</Project>
-      <Name>GW2NET.V1.Floors</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.Floors.Tests/packages.config
+++ b/src/GW2NET.V1.Floors.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Floors/GW2NET.V1.Floors.csproj
+++ b/src/GW2NET.V1.Floors/GW2NET.V1.Floors.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A5AD09EB-690C-4ADC-8AF0-F0ACFAAE2F8F}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V1.Guilds.Tests/GW2NET.V1.Guilds.Tests.csproj
+++ b/src/GW2NET.V1.Guilds.Tests/GW2NET.V1.Guilds.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{0D1F86B9-70CD-4273-9353-72C0F5639BFC}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.Guilds\GW2NET.V1.Guilds.csproj">
+      <Project>{48dbec9e-c97b-412e-ad3a-03658f76cdfc}</Project>
+      <Name>GW2NET.V1.Guilds</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.Guilds\GW2NET.V1.Guilds.csproj">
-      <Project>{48dbec9e-c97b-412e-ad3a-03658f76cdfc}</Project>
-      <Name>GW2NET.V1.Guilds</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.Guilds.Tests/packages.config
+++ b/src/GW2NET.V1.Guilds.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Guilds/GW2NET.V1.Guilds.csproj
+++ b/src/GW2NET.V1.Guilds/GW2NET.V1.Guilds.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{48DBEC9E-C97B-412E-AD3A-03658F76CDFC}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V1.Items.Tests/GW2NET.V1.Items.Tests.csproj
+++ b/src/GW2NET.V1.Items.Tests/GW2NET.V1.Items.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{643AB801-F173-4995-8158-3AA461695943}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.Items\GW2NET.V1.Items.csproj">
+      <Project>{d408e5b0-40f7-4262-8d8a-b30bb2de1e93}</Project>
+      <Name>GW2NET.V1.Items</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.Items\GW2NET.V1.Items.csproj">
-      <Project>{d408e5b0-40f7-4262-8d8a-b30bb2de1e93}</Project>
-      <Name>GW2NET.V1.Items</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.Items.Tests/packages.config
+++ b/src/GW2NET.V1.Items.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Items/GW2NET.V1.Items.csproj
+++ b/src/GW2NET.V1.Items/GW2NET.V1.Items.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{D408E5B0-40F7-4262-8D8A-B30BB2DE1E93}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V1.Maps.Tests/GW2NET.V1.Maps.Tests.csproj
+++ b/src/GW2NET.V1.Maps.Tests/GW2NET.V1.Maps.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{94C3A0A9-6C71-4120-814B-5C97CDB5BEE1}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.Maps\GW2NET.V1.Maps.csproj">
+      <Project>{19481b9a-67f2-4bec-824e-731c7238d7e4}</Project>
+      <Name>GW2NET.V1.Maps</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.Maps\GW2NET.V1.Maps.csproj">
-      <Project>{19481b9a-67f2-4bec-824e-731c7238d7e4}</Project>
-      <Name>GW2NET.V1.Maps</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.Maps.Tests/packages.config
+++ b/src/GW2NET.V1.Maps.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Maps/GW2NET.V1.Maps.csproj
+++ b/src/GW2NET.V1.Maps/GW2NET.V1.Maps.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{19481B9A-67F2-4BEC-824E-731C7238D7E4}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V1.Recipes.Tests/GW2NET.V1.Recipes.Tests.csproj
+++ b/src/GW2NET.V1.Recipes.Tests/GW2NET.V1.Recipes.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{2C6FB74B-A7E5-4DE2-80A0-7108941CEEE4}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.Recipes\GW2NET.V1.Recipes.csproj">
+      <Project>{b476c1ef-2fb8-4590-a5e3-cca93d079b21}</Project>
+      <Name>GW2NET.V1.Recipes</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.Recipes\GW2NET.V1.Recipes.csproj">
-      <Project>{b476c1ef-2fb8-4590-a5e3-cca93d079b21}</Project>
-      <Name>GW2NET.V1.Recipes</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.Recipes.Tests/packages.config
+++ b/src/GW2NET.V1.Recipes.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Recipes/GW2NET.V1.Recipes.csproj
+++ b/src/GW2NET.V1.Recipes/GW2NET.V1.Recipes.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{B476C1EF-2FB8-4590-A5E3-CCA93D079B21}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/GW2NET.V1.Skins.Tests/GW2NET.V1.Skins.Tests.csproj
+++ b/src/GW2NET.V1.Skins.Tests/GW2NET.V1.Skins.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{56485271-9D45-41CB-AA3B-7A5E64C00850}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.Skins\GW2NET.V1.Skins.csproj">
+      <Project>{0ac8e33c-64b8-496b-a202-924375af0d39}</Project>
+      <Name>GW2NET.V1.Skins</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.Skins\GW2NET.V1.Skins.csproj">
-      <Project>{0ac8e33c-64b8-496b-a202-924375af0d39}</Project>
-      <Name>GW2NET.V1.Skins</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.Skins.Tests/packages.config
+++ b/src/GW2NET.V1.Skins.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Skins/GW2NET.V1.Skins.csproj
+++ b/src/GW2NET.V1.Skins/GW2NET.V1.Skins.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{0AC8E33C-64B8-496B-A202-924375AF0D39}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V1.WorldVersusWorld.Matches.Tests/GW2NET.V1.WorldVersusWorld.Matches.Tests.csproj
+++ b/src/GW2NET.V1.WorldVersusWorld.Matches.Tests/GW2NET.V1.WorldVersusWorld.Matches.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{C037B8E6-6DA7-41F8-B3BB-D356605331C3}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.WorldVersusWorld.Matches\GW2NET.V1.WorldVersusWorld.Matches.csproj">
+      <Project>{d53ae2ca-1a84-4707-8099-b6003ffac46e}</Project>
+      <Name>GW2NET.V1.WorldVersusWorld.Matches</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.WorldVersusWorld.Matches\GW2NET.V1.WorldVersusWorld.Matches.csproj">
-      <Project>{d53ae2ca-1a84-4707-8099-b6003ffac46e}</Project>
-      <Name>GW2NET.V1.WorldVersusWorld.Matches</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.WorldVersusWorld.Matches.Tests/packages.config
+++ b/src/GW2NET.V1.WorldVersusWorld.Matches.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.WorldVersusWorld.Matches/GW2NET.V1.WorldVersusWorld.Matches.csproj
+++ b/src/GW2NET.V1.WorldVersusWorld.Matches/GW2NET.V1.WorldVersusWorld.Matches.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{D53AE2CA-1A84-4707-8099-B6003FFAC46E}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V1.WorldVersusWorld.Objectives.Tests/GW2NET.V1.WorldVersusWorld.Objectives.Tests.csproj
+++ b/src/GW2NET.V1.WorldVersusWorld.Objectives.Tests/GW2NET.V1.WorldVersusWorld.Objectives.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{6E237424-818F-4D25-BE7D-6C61691B9B56}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.WorldVersusWorld.Objectives\GW2NET.V1.WorldVersusWorld.Objectives.csproj">
+      <Project>{926e82ec-49d0-43f2-8214-e06408619676}</Project>
+      <Name>GW2NET.V1.WorldVersusWorld.Objectives</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.WorldVersusWorld.Objectives\GW2NET.V1.WorldVersusWorld.Objectives.csproj">
-      <Project>{926e82ec-49d0-43f2-8214-e06408619676}</Project>
-      <Name>GW2NET.V1.WorldVersusWorld.Objectives</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.WorldVersusWorld.Objectives.Tests/packages.config
+++ b/src/GW2NET.V1.WorldVersusWorld.Objectives.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.WorldVersusWorld.Objectives/GW2NET.V1.WorldVersusWorld.Objectives.csproj
+++ b/src/GW2NET.V1.WorldVersusWorld.Objectives/GW2NET.V1.WorldVersusWorld.Objectives.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{926E82EC-49D0-43F2-8214-E06408619676}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V1.Worlds.Tests/GW2NET.V1.Worlds.Tests.csproj
+++ b/src/GW2NET.V1.Worlds.Tests/GW2NET.V1.Worlds.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{7413DF0B-8513-42ED-9470-5217F18250A0}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V1.Worlds\GW2NET.V1.Worlds.csproj">
+      <Project>{f3e6f8e8-2767-4a99-bad4-20b7d0edcd96}</Project>
+      <Name>GW2NET.V1.Worlds</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V1.Worlds\GW2NET.V1.Worlds.csproj">
-      <Project>{f3e6f8e8-2767-4a99-bad4-20b7d0edcd96}</Project>
-      <Name>GW2NET.V1.Worlds</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V1.Worlds.Tests/packages.config
+++ b/src/GW2NET.V1.Worlds.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V1.Worlds/GW2NET.V1.Worlds.csproj
+++ b/src/GW2NET.V1.Worlds/GW2NET.V1.Worlds.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{F3E6F8E8-2767-4A99-BAD4-20B7D0EDCD96}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Account/GW2NET.V2.Accounts.csproj
+++ b/src/GW2NET.V2.Account/GW2NET.V2.Accounts.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{2C83D314-3C3F-470B-A4CC-B6E3E1F48EA2}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Accounts.Characters/GW2NET.V2.Accounts.Characters.csproj
+++ b/src/GW2NET.V2.Accounts.Characters/GW2NET.V2.Accounts.Characters.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{9D582BC4-D182-4373-A8D5-04607F4094B1}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Builds.Tests/GW2NET.V2.Builds.Tests.csproj
+++ b/src/GW2NET.V2.Builds.Tests/GW2NET.V2.Builds.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{D431AA14-5D60-46CD-B4D5-3C67397C2B01}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -56,6 +56,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -75,9 +78,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V2.Builds.Tests/packages.config
+++ b/src/GW2NET.V2.Builds.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Builds/GW2NET.V2.Builds.csproj
+++ b/src/GW2NET.V2.Builds/GW2NET.V2.Builds.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{5F2C2514-10B0-4B5B-B227-EDD406377396}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Colors.Tests/GW2NET.V2.Colors.Tests.csproj
+++ b/src/GW2NET.V2.Colors.Tests/GW2NET.V2.Colors.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{015D5CB4-B8F3-4197-AD37-B3CBDC571EA4}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -49,6 +49,20 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V2.Colors\GW2NET.V2.Colors.csproj">
+      <Project>{d5fd21bd-9d1f-4129-b3dd-fcdc0afd0830}</Project>
+      <Name>GW2NET.V2.Colors</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -68,20 +82,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V2.Colors\GW2NET.V2.Colors.csproj">
-      <Project>{d5fd21bd-9d1f-4129-b3dd-fcdc0afd0830}</Project>
-      <Name>GW2NET.V2.Colors</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V2.Colors.Tests/packages.config
+++ b/src/GW2NET.V2.Colors.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Colors/GW2NET.V2.Colors.csproj
+++ b/src/GW2NET.V2.Colors/GW2NET.V2.Colors.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{D5FD21BD-9D1F-4129-B3DD-FCDC0AFD0830}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Commerce.Exchange.Tests/GW2NET.V2.Commerce.Exchange.Tests.csproj
+++ b/src/GW2NET.V2.Commerce.Exchange.Tests/GW2NET.V2.Commerce.Exchange.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{E8670EC0-899C-416A-A73B-BF62C42E9CDE}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -45,6 +45,19 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V2.Commerce.Exchange\GW2NET.V2.Commerce.Exchange.csproj">
+      <Project>{40a8f55c-97bc-4652-a60e-9f4ea5d49fda}</Project>
+      <Name>GW2NET.V2.Commerce.Exchange</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -64,19 +77,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V2.Commerce.Exchange\GW2NET.V2.Commerce.Exchange.csproj">
-      <Project>{40a8f55c-97bc-4652-a60e-9f4ea5d49fda}</Project>
-      <Name>GW2NET.V2.Commerce.Exchange</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V2.Commerce.Exchange.Tests/packages.config
+++ b/src/GW2NET.V2.Commerce.Exchange.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Commerce.Exchange/GW2NET.V2.Commerce.Exchange.csproj
+++ b/src/GW2NET.V2.Commerce.Exchange/GW2NET.V2.Commerce.Exchange.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{40A8F55C-97BC-4652-A60E-9F4EA5D49FDA}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Commerce.Listings.Tests/GW2NET.V2.Commerce.Listings.Tests.csproj
+++ b/src/GW2NET.V2.Commerce.Listings.Tests/GW2NET.V2.Commerce.Listings.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{55211BC2-D7F2-4EFA-A026-82DDECB2C9D8}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -45,6 +45,19 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V2.Commerce.Listings\GW2NET.V2.Commerce.Listings.csproj">
+      <Project>{ca6d86a9-f12e-45d4-a878-57f2714a0a51}</Project>
+      <Name>GW2NET.V2.Commerce.Listings</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -64,19 +77,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V2.Commerce.Listings\GW2NET.V2.Commerce.Listings.csproj">
-      <Project>{ca6d86a9-f12e-45d4-a878-57f2714a0a51}</Project>
-      <Name>GW2NET.V2.Commerce.Listings</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V2.Commerce.Listings.Tests/packages.config
+++ b/src/GW2NET.V2.Commerce.Listings.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Commerce.Listings/GW2NET.V2.Commerce.Listings.csproj
+++ b/src/GW2NET.V2.Commerce.Listings/GW2NET.V2.Commerce.Listings.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{CA6D86A9-F12E-45D4-A878-57F2714A0A51}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Commerce.Prices.Tests/GW2NET.V2.Commerce.Prices.Tests.csproj
+++ b/src/GW2NET.V2.Commerce.Prices.Tests/GW2NET.V2.Commerce.Prices.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{BD58BAD5-6414-4343-8D18-FAB92C490CDA}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V2.Commerce.Prices\GW2NET.V2.Commerce.Prices.csproj">
+      <Project>{0f72000c-a997-471f-a353-5988828a5255}</Project>
+      <Name>GW2NET.V2.Commerce.Prices</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V2.Commerce.Prices\GW2NET.V2.Commerce.Prices.csproj">
-      <Project>{0f72000c-a997-471f-a353-5988828a5255}</Project>
-      <Name>GW2NET.V2.Commerce.Prices</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V2.Commerce.Prices.Tests/packages.config
+++ b/src/GW2NET.V2.Commerce.Prices.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Commerce.Prices/GW2NET.V2.Commerce.Prices.csproj
+++ b/src/GW2NET.V2.Commerce.Prices/GW2NET.V2.Commerce.Prices.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{0F72000C-A997-471F-A353-5988828A5255}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Continents.Tests/GW2NET.V2.Continents.Tests.csproj
+++ b/src/GW2NET.V2.Continents.Tests/GW2NET.V2.Continents.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{AB7276EF-FC12-48E9-B2FF-42B26987C42E}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V2.Continents\GW2NET.V2.Continents.csproj">
+      <Project>{8991e557-f908-4ff4-9a3e-299869076887}</Project>
+      <Name>GW2NET.V2.Continents</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V2.Continents\GW2NET.V2.Continents.csproj">
-      <Project>{8991e557-f908-4ff4-9a3e-299869076887}</Project>
-      <Name>GW2NET.V2.Continents</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V2.Continents.Tests/packages.config
+++ b/src/GW2NET.V2.Continents.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Continents/GW2NET.V2.Continents.csproj
+++ b/src/GW2NET.V2.Continents/GW2NET.V2.Continents.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8991E557-F908-4FF4-9A3E-299869076887}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Files.Tests/GW2NET.V2.Files.Tests.csproj
+++ b/src/GW2NET.V2.Files.Tests/GW2NET.V2.Files.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{2F7B458D-A71B-40B0-BDD2-8BB8E11BD1FC}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -56,6 +56,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -75,9 +78,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V2.Files.Tests/packages.config
+++ b/src/GW2NET.V2.Files.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Files/GW2NET.V2.Files.csproj
+++ b/src/GW2NET.V2.Files/GW2NET.V2.Files.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{7376BF02-3192-479B-82E8-EC0B15DA55C1}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Items.Tests/GW2NET.V2.Items.Tests.csproj
+++ b/src/GW2NET.V2.Items.Tests/GW2NET.V2.Items.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A6E57E72-CD73-4B6B-A9C7-A368234CA6A5}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V2.Items\GW2NET.V2.Items.csproj">
+      <Project>{965994be-f908-4d34-af07-f8a6b527ffb7}</Project>
+      <Name>GW2NET.V2.Items</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V2.Items\GW2NET.V2.Items.csproj">
-      <Project>{965994be-f908-4d34-af07-f8a6b527ffb7}</Project>
-      <Name>GW2NET.V2.Items</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V2.Items.Tests/packages.config
+++ b/src/GW2NET.V2.Items.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Items/GW2NET.V2.Items.csproj
+++ b/src/GW2NET.V2.Items/GW2NET.V2.Items.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{965994BE-F908-4D34-AF07-F8A6B527FFB7}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Maps.Tests/GW2NET.V2.Maps.Tests.csproj
+++ b/src/GW2NET.V2.Maps.Tests/GW2NET.V2.Maps.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{6F7AF5C8-51C7-4A75-8236-A76456E0D753}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V2.Maps\GW2NET.V2.Maps.csproj">
+      <Project>{e0048487-3e7f-4036-bc50-508af4c321e2}</Project>
+      <Name>GW2NET.V2.Maps</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V2.Maps\GW2NET.V2.Maps.csproj">
-      <Project>{e0048487-3e7f-4036-bc50-508af4c321e2}</Project>
-      <Name>GW2NET.V2.Maps</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V2.Maps.Tests/packages.config
+++ b/src/GW2NET.V2.Maps.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Maps/GW2NET.V2.Maps.csproj
+++ b/src/GW2NET.V2.Maps/GW2NET.V2.Maps.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{E0048487-3E7F-4036-BC50-508AF4C321E2}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Quaggans.Tests/GW2NET.V2.Quaggans.Tests.csproj
+++ b/src/GW2NET.V2.Quaggans.Tests/GW2NET.V2.Quaggans.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8D0E77A4-5B93-4BB4-8328-A36D2DBD1ABB}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V2.Quaggans\GW2NET.V2.Quaggans.csproj">
+      <Project>{1de9b06c-24a1-497d-bfa9-65eb9e361c71}</Project>
+      <Name>GW2NET.V2.Quaggans</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V2.Quaggans\GW2NET.V2.Quaggans.csproj">
-      <Project>{1de9b06c-24a1-497d-bfa9-65eb9e361c71}</Project>
-      <Name>GW2NET.V2.Quaggans</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V2.Quaggans.Tests/packages.config
+++ b/src/GW2NET.V2.Quaggans.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Quaggans/GW2NET.V2.Quaggans.csproj
+++ b/src/GW2NET.V2.Quaggans/GW2NET.V2.Quaggans.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{1DE9B06C-24A1-497D-BFA9-65EB9E361C71}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Recipes.Tests/GW2NET.V2.Recipes.Tests.csproj
+++ b/src/GW2NET.V2.Recipes.Tests/GW2NET.V2.Recipes.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{66550043-D66C-4B98-A2A2-5E56A9AF7908}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V2.Recipes\GW2NET.V2.Recipes.csproj">
+      <Project>{55897753-f4b5-48d1-8a01-20d54afde7dd}</Project>
+      <Name>GW2NET.V2.Recipes</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V2.Recipes\GW2NET.V2.Recipes.csproj">
-      <Project>{55897753-f4b5-48d1-8a01-20d54afde7dd}</Project>
-      <Name>GW2NET.V2.Recipes</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V2.Recipes.Tests/packages.config
+++ b/src/GW2NET.V2.Recipes.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Recipes/GW2NET.V2.Recipes.csproj
+++ b/src/GW2NET.V2.Recipes/GW2NET.V2.Recipes.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{55897753-F4B5-48D1-8A01-20D54AFDE7DD}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Skins.Tests/GW2NET.V2.Skins.Tests.csproj
+++ b/src/GW2NET.V2.Skins.Tests/GW2NET.V2.Skins.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{2A32B1BA-B3CF-413A-BC09-163EE4E3B684}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -44,6 +44,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
+      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
+      <Name>GW2NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GW2NET.V2.Skins\GW2NET.V2.Skins.csproj">
+      <Project>{9937adf8-ceb8-48f2-9e12-c259cd454c17}</Project>
+      <Name>GW2NET.V2.Skins</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -63,16 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GW2NET.Core\GW2NET.Core.csproj">
-      <Project>{05f3d999-0470-4123-8c80-af4ac2385e7c}</Project>
-      <Name>GW2NET.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GW2NET.V2.Skins\GW2NET.V2.Skins.csproj">
-      <Project>{9937adf8-ceb8-48f2-9e12-c259cd454c17}</Project>
-      <Name>GW2NET.V2.Skins</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/GW2NET.V2.Skins.Tests/packages.config
+++ b/src/GW2NET.V2.Skins.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Skins/GW2NET.V2.Skins.csproj
+++ b/src/GW2NET.V2.Skins/GW2NET.V2.Skins.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{9937ADF8-CEB8-48F2-9E12-C259CD454C17}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Worlds.Tests/GW2NET.V2.Worlds.Tests.csproj
+++ b/src/GW2NET.V2.Worlds.Tests/GW2NET.V2.Worlds.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{7EF7A6AF-BCBA-43E7-9819-528DB8137755}</ProjectGuid>
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET.V2.Worlds.Tests/packages.config
+++ b/src/GW2NET.V2.Worlds.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable-net45+win+wpa81" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="xunit" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable46-net451+win81+wpa81" />
 </packages>

--- a/src/GW2NET.V2.Worlds/GW2NET.V2.Worlds.csproj
+++ b/src/GW2NET.V2.Worlds/GW2NET.V2.Worlds.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{1D9EEE65-D035-4ACB-9F08-883A59331A6A}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/GW2NET/GW2NET.csproj
+++ b/src/GW2NET/GW2NET.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{48C94F34-B6BD-4BDD-A0D5-36403A86FB78}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -253,7 +253,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.6\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.6\lib\portable-net45+wp80+win8+wpa81+aspnetcore50\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/GW2NET/packages.config
+++ b/src/GW2NET/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="portable46-net451+win81+wpa81" />
 </packages>


### PR DESCRIPTION
This PR changes the target framework to .NET 4.6 and drops support for Windows 8 store apps (8.1 is still supported).
